### PR TITLE
resolves MRO error in MutualAuth class in Python3

### DIFF
--- a/falcon_mutualauth/mutualauth.py
+++ b/falcon_mutualauth/mutualauth.py
@@ -21,7 +21,7 @@ from twisted.web.server import Request
 logger = structlog.get_logger()
 
 
-class MutualAuthRequest(object, Request):
+class MutualAuthRequest(Request):
 
     """HTTP request received over mutually-authenticated TLS.
 
@@ -37,12 +37,6 @@ class MutualAuthRequest(object, Request):
     """
 
     roles_map = {}
-
-    def __init__(self, channel, queued):
-        # Separate the old-style class from new-style class to avoid unexpected
-        # MRO by explicitly calling the superclasses' __init__s separately
-        super(MutualAuthRequest, self).__init__()
-        Request.__init__(self, channel, queued)
 
     def _inject_headers(self):
         peer_cert = self.channel.transport.getPeerCertificate()


### PR DESCRIPTION
Helping @fboxwala open this PR since she said she had a permissions problem.

@lvh, I had switched the order of these classes per your instruction; this PR would essentially revert that (complete commit in question: https://github.com/RackSec/overcorps/pull/78/commits/3bdf689ce481b9779bf6055a18a191fdd826a0f4)

@fboxwala, can you give more detail on why you want to do this?
